### PR TITLE
Add authentication

### DIFF
--- a/handler_auth.go
+++ b/handler_auth.go
@@ -16,6 +16,9 @@ var (
 	authTypeRegistry map[string]reflect.Type = map[string]reflect.Type{
 		"NoAuth":    reflect.TypeOf(NoAuth{}),
 		"BasicAuth": reflect.TypeOf(BasicAuth{}),
+		"IPAuth": reflect.TypeOf(IPAuth{}),
+		"S3ReadAuth": reflect.TypeOf(S3ReadAuth{}),
+		"S3WriteAuth": reflect.TypeOf(S3WriteAuth{}),
 	}
 )
 

--- a/handler_auth.go
+++ b/handler_auth.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/TakatoshiMaeda/kinu/logger"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+)
+
+var (
+	authenticationStack map[string][]Auth = map[string][]Auth{}
+	authTypeRegistry map[string]reflect.Type = map[string]reflect.Type{
+		"NoAuth":    reflect.TypeOf(NoAuth{}),
+		"BasicAuth": reflect.TypeOf(BasicAuth{}),
+	}
+)
+
+type Auth interface {
+	Authenticate(r *http.Request, ps httprouter.Params) bool
+	HandleAuthError(w http.ResponseWriter, r *http.Request, ps httprouter.Params) bool
+	SuccessLogLevel() string
+	FailureLogLevel() string
+}
+
+type AbstractAuth struct {
+}
+
+func (a *AbstractAuth) GetLogLevel(key string, def string) string {
+	level := viper.GetString(key)
+	if level == "" {
+		return def
+	}
+	return level
+}
+
+func (a *AbstractAuth) SuccessLogLevel() string {
+	return "Info"
+}
+
+func (a *AbstractAuth) FailureLogLevel() string {
+	return "Warn"
+}
+
+type NoAuth struct {
+	*AbstractAuth
+}
+
+func (a NoAuth) Authenticate(r *http.Request, ps httprouter.Params) bool {
+	return true
+}
+
+func (a NoAuth) HandleAuthError(w http.ResponseWriter, r *http.Request, ps httprouter.Params) bool {
+	return false
+}
+
+func createAuthInstance(name string) Auth {
+	elem := reflect.New(authTypeRegistry[name]).Elem()
+	return elem.Interface().(Auth)
+}
+
+func InitAuthStack() {
+	viper.SetEnvPrefix("kinu")
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetConfigName("kinu_auth")
+	viper.AddConfigPath(".")
+	viper.ReadInConfig()
+	if os.Getenv("KINU_DEBUG") == "1" {
+		viper.Debug()
+	}
+	for _, k := range []string{"images", "upload"} {
+		viper.SetDefault("resource." + k, []string{})
+		for _, v := range viper.GetStringSlice("resource." + k) {
+			authenticationStack[k] = append(authenticationStack[k], createAuthInstance(v))
+		}
+	}
+}
+
+func Authentication(resource string, h httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if authenticate(w, r, ps, authenticationStack[resource], 0) {
+			h(w, r, ps)
+		}
+	}
+}
+
+func authenticate(w http.ResponseWriter, r *http.Request, ps httprouter.Params, authStack []Auth, index int) bool {
+	if len(authStack) - 1 < index {
+		return true
+	}
+	auth := authStack[index]
+	if auth.Authenticate(r, ps) {
+		// auth success
+		logger.Log(logger.WithFields(logrus.Fields{
+			"path":   r.URL.Path,
+			"params": r.URL.Query(),
+			"method": r.Method,
+			"auth": reflect.TypeOf(auth),
+		}), auth.SuccessLogLevel(), "success")
+		index += 1
+		return authenticate(w, r, ps, authStack, index)
+	}
+	// auth error
+	logger.Log(logger.WithFields(logrus.Fields{
+		"path":   r.URL.Path,
+		"params": r.URL.Query(),
+		"method": r.Method,
+		"auth": reflect.TypeOf(auth),
+	}), auth.FailureLogLevel(), "failure")
+	auth.HandleAuthError(w, r, ps)
+	return false
+}
+

--- a/handler_basic_auth.go
+++ b/handler_basic_auth.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/spf13/viper"
+	"net/http"
+	"strings"
+	"encoding/base64"
+	"bytes"
+)
+
+type BasicAuth struct {
+	*AbstractAuth
+}
+
+func (a BasicAuth) SuccessLogLevel() string {
+	return a.GetLogLevel("auth.basic_auth.success_log_level", "Info")
+}
+
+func (a BasicAuth) FailureLogLevel() string {
+	return a.GetLogLevel("auth.basic_auth.failure_log_level", "Warn")
+}
+
+func (a BasicAuth) Authenticate(r *http.Request, ps httprouter.Params) bool {
+	const basicAuthPrefix string = "Basic "
+
+	user := viper.GetString("auth.basic_auth.user")
+	pass := viper.GetString("auth.basic_auth.pass")
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, basicAuthPrefix) {
+		payload, err := base64.StdEncoding.DecodeString(auth[len(basicAuthPrefix):])
+		if err == nil {
+			pair := bytes.SplitN(payload, []byte(":"), 2)
+			if len(pair) == 2 &&
+				bytes.Equal(pair[0], []byte(user)) &&
+				bytes.Equal(pair[1], []byte(pass)) {
+				return true
+			}
+		}
+	}	
+	return false
+}
+
+func (a BasicAuth) HandleAuthError(w http.ResponseWriter, r *http.Request, ps httprouter.Params) bool {
+	w.Header().Set("WWW-Authenticate", "Basic realm=Restricted")
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	return true
+}

--- a/handler_ip_auth.go
+++ b/handler_ip_auth.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/spf13/viper"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type IPAuth struct {
+	*AbstractAuth
+}
+
+func (a IPAuth) SuccessLogLevel() string {
+	return a.GetLogLevel("auth.ip_auth.success_log_level", "Info")
+}
+
+func (a IPAuth) FailureLogLevel() string {
+	return a.GetLogLevel("auth.ip_auth.failure_log_level", "Warn")
+}
+
+func (a IPAuth) Authenticate(r *http.Request, ps httprouter.Params) bool {
+	line := r.Header.Get("X-Forwarded-For")
+	ip := strings.TrimSpace(strings.Split(line, ",")[0])
+	if ip == "" {
+		ip, _, _ = net.SplitHostPort(r.RemoteAddr)
+	}
+	permitIps := viper.GetStringSlice("auth.ip_auth.ips")
+	for _, v := range permitIps {
+		if v == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func (a IPAuth) HandleAuthError(w http.ResponseWriter, r *http.Request, ps httprouter.Params) bool {
+	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+	return true
+}

--- a/handler_s3_read_auth.go
+++ b/handler_s3_read_auth.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	awsSession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"os"
+	"net/http"
+)
+
+type S3ReadAuth struct {
+	AbstractAuth
+}
+
+func (a S3ReadAuth) SuccessLogLevel() string {
+	return a.GetLogLevel("auth.s3_read_auth.success_log_level", "Info")
+}
+
+func (a S3ReadAuth) FailureLogLevel() string {
+	return a.GetLogLevel("auth.s3_read_auth.failure_log_level", "Warn")
+}
+
+func (a S3ReadAuth) Authenticate(r *http.Request, ps httprouter.Params) bool {
+	accessKeyId := r.FormValue("access_key_id")
+	secretAccessKey := r.FormValue("secret_access_key")
+	sessionToken := r.FormValue("session_token")
+	cred := credentials.NewStaticCredentials(accessKeyId, secretAccessKey, sessionToken)
+	client := s3.New(awsSession.New(), &aws.Config{Credentials: cred, Region: aws.String(os.Getenv("KINU_S3_REGION"))})
+	params := &s3.GetObjectInput{
+		Bucket: aws.String(os.Getenv("KINU_S3_BUCKET")),
+		Key:    aws.String("kinu_access_check"),
+	}
+	_, err := client.GetObject(params)
+	if reqerr, ok := err.(awserr.RequestFailure); ok && reqerr.StatusCode() == http.StatusNotFound {
+		return true
+	} else if err != nil {
+		return false
+	}
+	return true
+}
+
+func (a S3ReadAuth) HandleAuthError(w http.ResponseWriter, r *http.Request, ps httprouter.Params) bool {
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	return true
+}
+

--- a/handler_s3_write_auth.go
+++ b/handler_s3_write_auth.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"github.com/julienschmidt/httprouter"
+	"github.com/aws/aws-sdk-go/aws"
+	awsSession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"os"
+	"net/http"
+)
+
+type S3WriteAuth struct {
+	AbstractAuth
+}
+
+func (a S3WriteAuth) SuccessLogLevel() string {
+	return a.GetLogLevel("auth.s3_write_auth.success_log_level", "Info")
+}
+
+func (a S3WriteAuth) FailureLogLevel() string {
+	return a.GetLogLevel("auth.s3_write_auth.failure_log_level", "Warn")
+}
+
+func (a S3WriteAuth) Authenticate(r *http.Request, ps httprouter.Params) bool {
+	accessKeyId := r.FormValue("access_key_id")
+	secretAccessKey := r.FormValue("secret_access_key")
+	sessionToken := r.FormValue("session_token")
+	cred := credentials.NewStaticCredentials(accessKeyId, secretAccessKey, sessionToken)
+	client := s3.New(awsSession.New(), &aws.Config{Credentials: cred, Region: aws.String(os.Getenv("KINU_S3_REGION"))})
+	_, err := client.PutObject(&s3.PutObjectInput{
+		Bucket:   aws.String(os.Getenv("KINU_S3_BUCKET")),
+		Key:      aws.String("kinu_write_check"),
+		Body:     bytes.NewReader([]byte("dummy")),
+	})
+
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func (a S3WriteAuth) HandleAuthError(w http.ResponseWriter, r *http.Request, ps httprouter.Params) bool {
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	return true
+}
+

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -36,6 +36,25 @@ func WithFields(fields logrus.Fields) *logrus.Entry {
 	return logrus.WithFields(fields)
 }
 
+func Log(entry *logrus.Entry, level string, args ...interface{}) {
+	switch level {
+	case "Info":
+		entry.Info(args)
+	case "Debug":
+		entry.Debug(args)
+	case "Warn":
+		entry.Warn(args)
+	case "Error":
+		entry.Error(args)
+	case "Fatal":
+		entry.Fatal(args)
+	case "Panic":
+		entry.Panic(args)
+	default:
+		entry.Panic(args)
+	}
+}
+
 func Debug(args ...interface{}) {
 	logrus.Debug(args)
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	engine.Initialize()
 	defer engine.Finalize()
+	InitAuthStack()
 
 	router := httprouter.New()
 
@@ -46,11 +47,11 @@ func main() {
 		router.GET("/debug/pprof/symbol", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) { pprof.Symbol(w, r) })
 	}
 
-	router.GET("/images/:type/:geometry/:filename", GetImageHandler)
+	router.GET("/images/:type/:geometry/:filename", Authentication("images", GetImageHandler))
 
-	router.POST("/upload", UploadImageHandler)
-	router.POST("/sandbox", UploadImageToSandboxHandler)
-	router.POST("/sandbox/attach", ApplyFromSandboxHandler)
+	router.POST("/upload", Authentication("upload", UploadImageHandler))
+	router.POST("/sandbox", Authentication("upload", UploadImageToSandboxHandler))
+	router.POST("/sandbox/attach", Authentication("upload", ApplyFromSandboxHandler))
 
 	logger.Fatal(http.ListenAndServe(":"+listenPort, router))
 }


### PR DESCRIPTION
認証周りの仕組みをいれてみました。
handlerをラップする形で認証スタックを挟み込めるようにしました。
認証スタックは`images`と`upload`の2つあり、それぞれ別の認証を書けられるようにしています。
### 設定ファイルによる指定

``` json
{
  "resource": {
    "images": ["NoAuth", "BasicAuth"],
    "upload": ["BasicAuth"]
  },
  "auth": {
    "basic_auth": {
      "user": "kinu",
      "pass": "test"
    }
  }
}
```
### 環境変数による指定

``` shell
export KINU_RESOURCE_IMAGES="BasicAuth"
export KINU_AUTH_BASICAUTH_USER=kinu
export KINU_AUTH_BASICAUTH_PASS=test
kinu
```
