### PR TITLE
Resize coodinates calc from size hint

### DIFF
--- a/resizer/coodinates_calculator.go
+++ b/resizer/coodinates_calculator.go
@@ -66,10 +66,22 @@ func (c *CoodinatesCalculator) AutoCrop() (coodinates *Coodinates) {
 	return coodinates
 }
 
+func (c *CoodinatesCalculator) Calc(option *ResizeOption) (coodinates *Coodinates) {
+	if option.NeedsAutoCrop {
+		return c.AutoCrop()
+	} else {
+		return c.Resize()
+	}
+}
+
 type Coodinates struct {
 	ResizeWidth, ResizeHeight int
 	CropWidth, CropHeight     int
 	WidthOffset, HeightOffset int
+}
+
+func (c *Coodinates) Valid() bool {
+	return c.ResizeHeight > 0 && c.ResizeWidth > 0
 }
 
 func (c *Coodinates) CanCrop() bool {

--- a/resizer/runner.go
+++ b/resizer/runner.go
@@ -9,16 +9,6 @@ import (
 	"strconv"
 )
 
-type ResizeOption struct {
-	Width         int
-	Height        int
-	NeedsAutoCrop bool
-	Quality       int
-
-	SizeHintWidth  int
-	SizeHintHeight int
-}
-
 type ResizeRequest struct {
 	image      []byte
 	option     *ResizeOption
@@ -123,4 +113,18 @@ func dispatch(image []byte, option *ResizeOption) (resultChan chan *ResizeResult
 	}
 	resizeRequestDispatcher <- request
 	return request.resultChan
+}
+
+type ResizeOption struct {
+	Width         int
+	Height        int
+	NeedsAutoCrop bool
+	Quality       int
+
+	SizeHintWidth  int
+	SizeHintHeight int
+}
+
+func (o *ResizeOption) HasSizeHint() bool {
+	return o.SizeHintHeight > 0 && o.SizeHintWidth > 0
 }


### PR DESCRIPTION
Broken jpeg size hint...
Enable the jpeg size hint will to faster resize process
