### PR TITLE
Handle orientation and remove properties

### DIFF
--- a/engine/image_magick.go
+++ b/engine/image_magick.go
@@ -64,14 +64,14 @@ func (e *ImageMagickEngine) Crop(width int, height int, startX int, startY int) 
 func (e *ImageMagickEngine) Generate() ([]byte, error) {
 	orientation := e.mw.GetImageOrientation()
 	if orientation != imagick.ORIENTATION_UNDEFINED && orientation != imagick.ORIENTATION_TOP_LEFT {
-		ok := e.mw.AutoOrientImage()
-		if ok != nil {
-			return nil, ok
+		err := e.mw.AutoOrientImage()
+		if err != nil {
+			return nil, err
 		}
 	}
-	ok := e.mw.StripImage()
-	if ok != nil {
-		return nil, ok
+	err := e.mw.StripImage()
+	if err != nil {
+		return nil, err
 	}
 	return e.mw.GetImageBlob(), nil
 }

--- a/engine/image_magick.go
+++ b/engine/image_magick.go
@@ -62,5 +62,16 @@ func (e *ImageMagickEngine) Crop(width int, height int, startX int, startY int) 
 }
 
 func (e *ImageMagickEngine) Generate() ([]byte, error) {
+	orientation := e.mw.GetImageOrientation()
+	if orientation != imagick.ORIENTATION_UNDEFINED && orientation != imagick.ORIENTATION_TOP_LEFT {
+		ok := e.mw.AutoOrientImage()
+		if ok != nil {
+			return nil, ok
+		}
+	}
+	ok := e.mw.StripImage()
+	if ok != nil {
+		return nil, ok
+	}
 	return e.mw.GetImageBlob(), nil
 }


### PR DESCRIPTION
cf. https://github.com/TakatoshiMaeda/kinu/issues/39

Exifのorientationのハンドリングを追加しました。
合わせて画像のプロパティ情報を削除（StripImage）するようにしました。

Generateに入れましたが、別の場所に入れたほうが良いようでしたら教えて下さい。
