### PR TITLE
Fix wrong image size metadata saving

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -130,7 +130,7 @@ func (s *S3Storage) PutFromBlob(key string, image []byte, metadata map[string]st
 func (s *S3Storage) Put(key string, imageFile io.ReadSeeker, metadata map[string]string) error {
 	putMetadata := make(map[string]*string, 0)
 	for k, v := range metadata {
-		putMetadata[k] = &v
+		putMetadata[k] = aws.String(v)
 	}
 
 	_, err := s.client.PutObject(&s3.PutObjectInput{


### PR DESCRIPTION
# Issue

Currently Kinu have a following issue when using S3 as storage.

Upload a rectangle image. (for example, the image size is 1000x1498)
The metadata of the uploaded image must have following elements.

- x-amz-meta-width: 1000
- x-amz-meta-height: 1498

But, actually is

- x-amz-meta-width: 1498
- x-amz-meta-height: 1498

# Cause

Variable of For statement uses same one. That's why width and height are stored same value.
See also https://play.golang.org/p/3-MmSXkGGd

# Solution

Use `Aws.String()` to solve.
