### PR TITLE
Remove tempfile when it become unnecessary

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -122,7 +122,10 @@ func (s *S3Storage) PutFromBlob(key string, image []byte, metadata map[string]st
 		return logger.ErrorDebug(err)
 	}
 
-	defer tmpfile.Close()
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name())
+	}()
 
 	return s.Put(key, tmpfile, metadata)
 }


### PR DESCRIPTION
Run out of disk space due to temporary files.

```
time:2017-06-26T23:20:12Z	level:error	msg:write /tmp/kinu-upload501888308: no space left on device	file:/usr/local/go/vendor/src/github.com/tokubai/kinu/storage/s3.go:122
time:2017-06-26T23:20:12Z	level:error	msg:write /tmp/kinu-upload525001475: no space left on device	file:/usr/local/go/vendor/src/github.com/tokubai/kinu/storage/s3.go:122
time:2017-06-26T23:20:12Z	level:error	msg:write /tmp/kinu-upload573197958: no space left on device	file:/usr/local/go/vendor/src/github.com/tokubai/kinu/storage/s3.go:122
time:2017-06-26T23:20:13Z	level:error	msg:write /tmp/kinu-upload338476077: no space left on device	file:/usr/local/go/vendor/src/github.com/tokubai/kinu/storage/s3.go:122
time:2017-06-26T23:20:13Z	level:error	msg:Upload error. cause, 1. write /tmp/kinu-upload501888308: no space left on device  2. write /tmp/kinu-upload525001475: no space left on device  3. write /tmp/kinu-upload573197958: no space left on device  4. write /tmp/kinu-upload338476077: no space left on device  	file:/usr/local/go/vendor/src/github.com/tokubai/kinu/main.go:123
```

This change let remove temporary file after it become unnecessary.