### PR TITLE
Fix DeleteObject key

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -204,7 +204,7 @@ func (s *S3Storage) Move(from string, to string) error {
 	}
 	_, err = s.client.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(fromKey),
+		Key:    aws.String(from),
 	})
 
 	if reqerr, ok := err.(awserr.RequestFailure); ok && reqerr.StatusCode() == http.StatusNotFound {


### PR DESCRIPTION
DeleteObject Key should not contain bucket name.

---

Attaching from sandbox fails because of Access Denied error.
`fromKey` variable contains bucket name and this variable is used for `CopyObject` method.
But `DeleteObject` method should not include bucket name for `Key`.

This will cause `Access Denied` from S3, because there is not such path.