### PR TITLE
Support more image type

### DIFF
--- a/engine/base.go
+++ b/engine/base.go
@@ -2,10 +2,11 @@ package engine
 
 import (
 	"errors"
+	"os"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/tokubai/kinu/logger"
 	"gopkg.in/gographics/imagick.v2/imagick"
-	"os"
 )
 
 type ResizeEngine interface {
@@ -13,6 +14,7 @@ type ResizeEngine interface {
 	Close()
 
 	SetSizeHint(width, height int)
+	SetFormat(format string)
 
 	GetImageHeight() int
 	GetImageWidth() int

--- a/engine/image_magick.go
+++ b/engine/image_magick.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+
 	"github.com/tokubai/kinu/logger"
 	"gopkg.in/gographics/imagick.v2/imagick"
 )
@@ -23,6 +24,14 @@ func newImageMagickEngine(image []byte) (e *ImageMagickEngine) {
 func (e *ImageMagickEngine) SetSizeHint(width int, height int) {
 	e.heightSizeHint = height
 	e.widthSizeHint = width
+}
+
+func (e *ImageMagickEngine) SetFormat(format string) {
+	if format == "data" {
+		e.mw.SetImageFormat("jpeg")
+	} else {
+		e.mw.SetImageFormat(format)
+	}
 }
 
 func (e *ImageMagickEngine) Open() error {
@@ -73,5 +82,6 @@ func (e *ImageMagickEngine) Generate() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return e.mw.GetImageBlob(), nil
 }

--- a/handler_get_image.go
+++ b/handler_get_image.go
@@ -63,6 +63,7 @@ func GetImageHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Param
 	resizeOption := request.Geometry.ToResizeOption()
 	resizeOption.SizeHintHeight = image.Height
 	resizeOption.SizeHintWidth = image.Width
+	resizeOption.Format = request.Extension
 	resizedImage, err := resizer.Run(image.Body, resizeOption)
 	if err != nil {
 		if err == resizer.ErrTooManyRunningResizeWorker {

--- a/main.go
+++ b/main.go
@@ -87,14 +87,20 @@ func HandlePprof(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 
 func SetContentType(w http.ResponseWriter, filename string) error {
 	ext := ExtractExtension(filepath.Ext(filename))
-	if ext == "data" {
+	switch ext {
+	case "jpg", "jpeg":
+		w.Header().Set("Content-Type", "image/jpg")
+		return nil
+	case "png":
+		w.Header().Set("Content-Type", "image/png")
+		return nil
+	case "data":
 		w.Header().Set("Content-Type", "text/plain")
 		return nil
-	}
-	if IsValidImageExt(ext) {
-		w.Header().Set("Content-Type", "image/"+ext)
+	case "webp":
+		w.Header().Set("Content-Type", "image/webp")
 		return nil
-	} else {
+	default:
 		return ErrInvalidImageExt
 	}
 }

--- a/resizer/resize.go
+++ b/resizer/resize.go
@@ -75,6 +75,11 @@ func Resize(image []byte, option *ResizeOption) (result *ResizeResult) {
 		}
 	}
 
+	logger.Debug(option.Format)
+	if len(option.Format) != 0 {
+		engine.SetFormat(option.Format)
+	}
+
 	resultImage, err := engine.Generate()
 	return &ResizeResult{image: resultImage, err: err}
 }

--- a/resizer/runner.go
+++ b/resizer/runner.go
@@ -132,6 +132,8 @@ type ResizeOption struct {
 
 	SizeHintWidth  int
 	SizeHintHeight int
+
+	Format string
 }
 
 func (o *ResizeOption) HasSizeHint() bool {

--- a/resource/main.go
+++ b/resource/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	ValidExtensions     = []string{"jpg", "jpeg"}
+	ValidExtensions     = []string{"jpg", "jpeg", "png", "webp"}
 	imageFilePathRegexp *regexp.Regexp
 )
 

--- a/resource/main.go
+++ b/resource/main.go
@@ -201,8 +201,10 @@ func (r *Resource) Store(file io.ReadSeeker) error {
 		ext = "jpg"
 	case "image/jpg":
 		ext = "jpg"
+	case "image/png":
+		ext = "png"
 	default:
-		return &ErrStore{Message: "unsupported filetype, only support jpg"}
+		return &ErrStore{Message: "unsupported filetype, supported jpg or png"}
 	}
 
 	uploaders := make([]uploader.Uploader, 0)

--- a/resource/main.go
+++ b/resource/main.go
@@ -194,12 +194,13 @@ func (r *Resource) Store(file io.ReadSeeker) error {
 		return &ErrStore{Message: "invalid file"}
 	}
 
-	contentType := ""
+	ext := ""
+	contentType := http.DetectContentType(imageData)
 	switch http.DetectContentType(imageData) {
 	case "image/jpeg":
-		contentType = "jpg"
+		ext = "jpg"
 	case "image/jpg":
-		contentType = "jpg"
+		ext = "jpg"
 	default:
 		return &ErrStore{Message: "unsupported filetype, only support jpg"}
 	}
@@ -207,15 +208,17 @@ func (r *Resource) Store(file io.ReadSeeker) error {
 	uploaders := make([]uploader.Uploader, 0)
 	for _, size := range resizer.MiddleImageSizes {
 		uploader := &uploader.ImageUploader{
-			ImageBlob:  imageData,
-			Path:       r.FilePath(size),
-			UploadSize: size,
+			ImageBlob:   imageData,
+			Path:        r.FilePath(size),
+			UploadSize:  size,
+			ContentType: contentType,
+			Ext:         ext,
 		}
 		uploaders = append(uploaders, uploader)
 	}
 	uploaders = append(uploaders,
 		&uploader.TextFileUploader{
-			Path: fmt.Sprintf("%s/filetype.%s", r.BasePath(), contentType),
+			Path: fmt.Sprintf("%s/filetype.%s", r.BasePath(), ext),
 		},
 	)
 

--- a/storage/base.go
+++ b/storage/base.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/tokubai/kinu/logger"
 )
@@ -13,8 +14,8 @@ type Storage interface {
 
 	Fetch(key string) (*Object, error)
 
-	PutFromBlob(key string, image []byte, metadata map[string]string) error
-	Put(key string, imageFile io.ReadSeeker, metadata map[string]string) error
+	PutFromBlob(key string, image []byte, contentType string, metadata map[string]string) error
+	Put(key string, imageFile io.ReadSeeker, contentType string, metadata map[string]string) error
 
 	List(key string) ([]StorageItem, error)
 

--- a/storage/file.go
+++ b/storage/file.go
@@ -2,13 +2,14 @@ package storage
 
 import (
 	"encoding/json"
-	"github.com/Sirupsen/logrus"
-	"github.com/tokubai/kinu/logger"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/tokubai/kinu/logger"
 )
 
 type FileStorage struct {
@@ -89,7 +90,7 @@ func (s *FileStorage) Fetch(key string) (*Object, error) {
 	return object, nil
 }
 
-func (s *FileStorage) PutFromBlob(key string, image []byte, metadata map[string]string) error {
+func (s *FileStorage) PutFromBlob(key string, image []byte, contentType string, metadata map[string]string) error {
 	key = s.BuildKey(key)
 
 	directory := filepath.Dir(key)
@@ -103,6 +104,8 @@ func (s *FileStorage) PutFromBlob(key string, image []byte, metadata map[string]
 	if err != nil {
 		return logger.ErrorDebug(err)
 	}
+
+	metadata["Content-Type"] = contentType
 
 	j, err := json.Marshal(metadata)
 	if err != nil {
@@ -118,12 +121,12 @@ func (s *FileStorage) PutFromBlob(key string, image []byte, metadata map[string]
 	return nil
 }
 
-func (s *FileStorage) Put(key string, imageFile io.ReadSeeker, metadata map[string]string) error {
+func (s *FileStorage) Put(key string, imageFile io.ReadSeeker, contentType string, metadata map[string]string) error {
 	image, err := ioutil.ReadAll(imageFile)
 	if err != nil {
 		return logger.ErrorDebug(err)
 	}
-	return s.PutFromBlob(key, image, metadata)
+	return s.PutFromBlob(key, image, contentType, metadata)
 }
 
 func (s *FileStorage) List(key string) ([]StorageItem, error) {

--- a/uploader/main.go
+++ b/uploader/main.go
@@ -60,9 +60,11 @@ type Uploader interface {
 
 type ImageUploader struct {
 	Uploader
-	Path       string
-	ImageBlob  []byte
-	UploadSize string
+	Path        string
+	ImageBlob   []byte
+	UploadSize  string
+	ContentType string
+	Ext         string
 }
 
 func (u *ImageUploader) NeedsResize() bool {
@@ -110,7 +112,7 @@ func (u *ImageUploader) Exec() error {
 		return logger.ErrorDebug(err)
 	}
 
-	return storage.PutFromBlob(u.Path, u.ImageBlob, map[string]string{"Width": strconv.Itoa(e.GetImageWidth()), "Height": strconv.Itoa(e.GetImageHeight())})
+	return storage.PutFromBlob(u.Path, u.ImageBlob, u.ContentType, map[string]string{"Width": strconv.Itoa(e.GetImageWidth()), "Height": strconv.Itoa(e.GetImageHeight())})
 }
 
 type TextFileUploader struct {
@@ -125,5 +127,5 @@ func (u *TextFileUploader) Exec() error {
 	if err != nil {
 		return logger.ErrorDebug(err)
 	}
-	return storage.PutFromBlob(u.Path, []byte(u.Body), map[string]string{})
+	return storage.PutFromBlob(u.Path, []byte(u.Body), "plain/text", map[string]string{})
 }


### PR DESCRIPTION
1. We addressed the issue where Content-Type is set to `binary/octet-stream` when uploading images to S3.
2. Support for uploading png images
3. It corresponds to acquisition of png image and webp image