### PR TITLE
Tweak ManualCrop() logic to keep the backward compatibility

### DIFF
--- a/resizer/coodinates_calculator.go
+++ b/resizer/coodinates_calculator.go
@@ -73,10 +73,30 @@ func (c *CoodinatesCalculator) ManualCrop(option *ResizeOption) (coodinates *Coo
 
 	assumeRatio := float64(c.ImageWidth) / float64(option.AssumptionWidth)
 
-	coodinates.CropHeight = int(float64(option.CropHeight) * assumeRatio)
-	coodinates.CropWidth = int(float64(option.CropWidth) * assumeRatio)
-	coodinates.WidthOffset = int(float64(option.CropWidthOffset) * assumeRatio)
-	coodinates.HeightOffset = int(float64(option.CropHeightOffset) * assumeRatio)
+	assumeWidthOffset := float64(option.CropWidthOffset) * assumeRatio
+	assumeHeightOffset := float64(option.CropHeightOffset) * assumeRatio
+
+	assumeWidth := float64(option.CropWidth) * assumeRatio
+	assumeHeight := float64(option.CropHeight) * assumeRatio
+
+	widthScaleRatio := float64(option.Width) / assumeWidth
+	heightScaleRatio := float64(option.Height) / assumeHeight
+
+	scaleRatio := math.Max(widthScaleRatio, heightScaleRatio)
+
+	assumeCropWidth := float64(option.Width) / scaleRatio
+	assumeCropHeight := float64(option.Height) / scaleRatio
+
+	if widthScaleRatio > heightScaleRatio {
+		assumeHeightOffset = assumeHeightOffset + ((assumeHeight - assumeCropHeight) / 2.0)
+	} else {
+		assumeWidthOffset = assumeWidthOffset + ((assumeWidth - assumeCropWidth) / 2.0)
+	}
+
+	coodinates.CropWidth = int(assumeCropWidth)
+	coodinates.CropHeight = int(assumeCropHeight)
+	coodinates.WidthOffset = int(assumeWidthOffset)
+	coodinates.HeightOffset = int(assumeHeightOffset)
 
 	coodinates.ResizeWidth = option.Width
 	coodinates.ResizeHeight = option.Height


### PR DESCRIPTION
I found that Kinu's ManualCrop mode generates the image distorted when I gave the different aspect ratio from original one.

This PR fixes the logic of geometry calculation in ManualCrop() to make it compatible with Tofu.

## Screenshot

| Original | Tofu | ManualCrop(before) | ManualCrop(after) |
| --- | --- | --- | --- |
| ![original](https://user-images.githubusercontent.com/2456043/33427182-c8cd0c3c-d607-11e7-8d43-1aed19fbbbe9.jpg) | ![tofu](https://user-images.githubusercontent.com/2456043/33427194-d6b1b442-d607-11e7-8ba6-37083e21e407.jpg) | ![kinu_before](https://user-images.githubusercontent.com/2456043/33427211-e6562f9a-d607-11e7-90e4-409b3bebe736.jpg) | ![kinu_after](https://user-images.githubusercontent.com/2456043/33427525-e5065650-d608-11e7-9272-fa6f2749e4ac.jpg) |

### Original
- width: 1000
- heightl 1333

### Cropping to...
- width: 600
- height: 600
- widthOffset: 0
- heightOffset: 118
- cropWidth: 600
- cropHeight: 405
- assumptionWidth: 600

> w=600,h=600,mc=true,wo=0,ho=118,cw=600,ch=405,aw=600
