### PR TITLE
Address breaking change in satori/go.uuid

### DIFF
--- a/handler_sandbox.go
+++ b/handler_sandbox.go
@@ -17,7 +17,11 @@ func UploadImageToSandboxHandler(w http.ResponseWriter, r *http.Request, ps http
 
 	r.ParseMultipartForm(0)
 
-	uuidObject, _ := uuid.NewV4()
+	uuidObject, err := uuid.NewV4()
+	if err != nil {
+		RespondInternalServerError(w, err)
+		return
+	}
 	imageId := uuidObject.String()
 
 	file, _, err := r.FormFile("image")

--- a/handler_sandbox.go
+++ b/handler_sandbox.go
@@ -17,7 +17,8 @@ func UploadImageToSandboxHandler(w http.ResponseWriter, r *http.Request, ps http
 
 	r.ParseMultipartForm(0)
 
-	imageId := uuid.NewV4().String()
+	uuidObject, _ := uuid.NewV4()
+	imageId := uuidObject.String()
 
 	file, _, err := r.FormFile("image")
 	if err != nil {

--- a/handler_sandbox.go
+++ b/handler_sandbox.go
@@ -17,12 +17,12 @@ func UploadImageToSandboxHandler(w http.ResponseWriter, r *http.Request, ps http
 
 	r.ParseMultipartForm(0)
 
-	uuidObject, err := uuid.NewV4()
+	uid, err := uuid.NewV4()
 	if err != nil {
 		RespondInternalServerError(w, err)
 		return
 	}
-	imageId := uuidObject.String()
+	imageId := uid.String()
 
 	file, _, err := r.FormFile("image")
 	if err != nil {


### PR DESCRIPTION
This PR fixes the error caused by breaking changes in satori/go.uuid package.
ref: https://github.com/satori/go.uuid/issues/66

---

I've faced the following error when I tried to build Kinu with latest commit hash.

```
HEAD is now at befc007 Bump to 1.0.0.alpha13
# github.com/tokubai/kinu
./handler_sandbox.go:20:23: multiple-value uuid.NewV4() in single-value context
```
