### PR TITLE
Fix a bug that content of the uploaded file will be empty when putted on S3

### DIFF
--- a/storage/backward_compatible_s3.go
+++ b/storage/backward_compatible_s3.go
@@ -140,7 +140,12 @@ func (s *BackwardCompatibleS3Storage) Put(key string, imageFile io.ReadSeeker, c
 		putMetadata[k] = aws.String(v)
 	}
 
-	_, err := s.client.PutObject(&s3.PutObjectInput{
+	_, err := imageFile.Seek(0, 0)
+	if err != nil {
+		return logger.ErrorDebug(err)
+	}
+
+	_, err = s.client.PutObject(&s3.PutObjectInput{
 		Bucket:      aws.String(s.bucket),
 		Key:         aws.String(s.BuildKey(key)),
 		ContentType: aws.String(contentType),

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -142,7 +142,12 @@ func (s *S3Storage) Put(key string, imageFile io.ReadSeeker, contentType string,
 		putMetadata[k] = aws.String(v)
 	}
 
-	_, err := s.client.PutObject(&s3.PutObjectInput{
+	_, err := imageFile.Seek(0, 0)
+	if err != nil {
+		return logger.ErrorDebug(err)
+	}
+
+	_, err = s.client.PutObject(&s3.PutObjectInput{
 		Bucket:      aws.String(s.bucket),
 		Key:         aws.String(s.BuildKey(key)),
 		ContentType: aws.String(contentType),


### PR DESCRIPTION
This PR fixes a problem at image upload caused by the update of aws-sdk-go package.

According to the issue comment bellow, the handling of io.ReaderSeeker had been changed in v1.12.77 https://github.com/aws/aws-sdk-go/commit/e926b1104535afe4737cee791cbc55bb01654ac6

https://github.com/aws/aws-sdk-go/issues/1962#issuecomment-407152863

Due to the update above, we can't upload an image to S3 properly with current build.
