### PR TITLE
Make sure the compression quality is applied to ImageMagick

### DIFF
--- a/engine/base.go
+++ b/engine/base.go
@@ -15,6 +15,7 @@ type ResizeEngine interface {
 
 	SetSizeHint(width, height int)
 	SetFormat(format string)
+	SetCompressionQuality(quality int)
 
 	GetImageHeight() int
 	GetImageWidth() int

--- a/engine/image_magick.go
+++ b/engine/image_magick.go
@@ -34,6 +34,10 @@ func (e *ImageMagickEngine) SetFormat(format string) {
 	}
 }
 
+func (e *ImageMagickEngine) SetCompressionQuality(quality int) {
+	e.mw.SetImageCompressionQuality(uint(quality))
+}
+
 func (e *ImageMagickEngine) Open() error {
 	e.mw = imagick.NewMagickWand()
 	if e.heightSizeHint > 0 && e.widthSizeHint > 0 {

--- a/resizer/resize.go
+++ b/resizer/resize.go
@@ -87,6 +87,8 @@ func Resize(image []byte, option *ResizeOption) (result *ResizeResult) {
 		engine.SetFormat(option.Format)
 	}
 
+	engine.SetCompressionQuality(option.Quality)
+
 	resultImage, err := engine.Generate()
 	return &ResizeResult{image: resultImage, err: err}
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug that the `q=` parameter does not work.

When I sent requests to Kinu with several patterns of `q=` parameter, I found that the file sizes are not changed regardless of specified value.
With my short investigation, I guess the compression quality seems not to be applied to ImageMagick.

## Concerns

- Does DEFAULT_QUALITY should be changed?
    - This change impacts all resized images which are requested without `q=` parameter because the default quality is changed internally.
    - Kinu defines the default quality as `70`, but it's not used accidentally for now.
    - and the definition at ImageMagick(for JPEG) is as bellow.
        > The default is to use the estimated quality of your input image if it can be determined, otherwise 92.
        - http://www.imagemagick.org/script/command-line-options.php#quality
        - In my case, the file size of resized images are the same with the one when specified `q=90` for now.
